### PR TITLE
Update Void Linux info

### DIFF
--- a/librehunt.js
+++ b/librehunt.js
@@ -689,11 +689,11 @@ var distros = [
       "gaming":0,
       "shortdes":"Void Linux is an independent Linux distribution that uses the XBPS package manager along with the runit init system.",
       "touch":0,
-      "desktops":"Enlightenment, Cinnamon, LXDE, Mate, and XFCE",
+      "desktops":"XFCE, or without",
       "link":"https://voidlinux.org/",
       "linuxexpertise":2,
       "codename":"void",
-      "donate":"https://liberapay.com/voidforum/donate",
+      "donate":"https://docs.voidlinux.org/contributing/index.html",
       "customtweaks":0,
    },
    {


### PR DESCRIPTION
Void linux now only officially provides XFCE or command line install images:

https://voidlinux.org/download/

The liberapay link was also dead. Void devs have mentioned that they do not want to accept donations and instead prefer code/maintenance contributions, so I've linked to the "Contributing" section of the Void manual instead.